### PR TITLE
Fixed

### DIFF
--- a/en_partut-ud-train.conllu
+++ b/en_partut-ud-train.conllu
@@ -33218,8 +33218,8 @@
 19	well	well	ADV	B	_	20	advmod	_	_
 20	go	go	VERB	V	VerbForm=Inf	7	ccomp	_	_
 21	hand	hand	NOUN	S	Number=Sing	20	obl	_	_
-22	in	in	ADP	E	_	21	fixed	_	_
-23	hand	hand	NOUN	S	Number=Sing	21	fixed	_	_
+22	in	in	ADP	E	_	23	case	_	_
+23	hand	hand	NOUN	S	Number=Sing	21	nmod	_	_
 24	with	with	ADP	E	_	27	case	_	_
 25	a	a	DET	RI	Definite=Ind|Number=Sing|PronType=Art	27	det	_	_
 26	rising	rise	VERB	V	Number=Sing|Tense=Pres|VerbForm=Part	27	acl	_	_

--- a/en_partut-ud-train.conllu
+++ b/en_partut-ud-train.conllu
@@ -10208,7 +10208,7 @@
 8	both	both	DET	DI	PronType=Ind	9	det	_	_
 9	reports	report	NOUN	S	Number=Plur	4	obl	_	_
 10	up	up	ADP	E	_	12	case	_	_
-11	for	for	ADP	E	_	10	fixed	_	_
+11	for	for	ADP	E	_	12	case	_	_
 12	debate	debate	NOUN	S	Number=Sing	4	obl	_	_
 13	today	today	ADV	B	_	4	advmod	_	SpaceAfter=No
 14	.	.	PUNCT	FS	_	4	punct	_	_

--- a/en_partut-ud-train.conllu
+++ b/en_partut-ud-train.conllu
@@ -35686,12 +35686,12 @@
 # text = Likewise, so long as member countries maintain fiscal sovereignty, a new mechanism to facilitate finger-wagging at countries that defy European budget rules will change nothing.
 1	Likewise	likewise	ADV	B	_	28	advmod	_	SpaceAfter=No
 2	,	,	PUNCT	FF	_	1	punct	_	_
-3	so	so	ADV	B	_	8	mark	_	_
-4	long	long	ADJ	A	Degree=Pos	3	fixed	_	_
-5	as	as	ADP	E	_	3	fixed	_	_
+3	so	so	ADV	B	_	4	advmod	_	_
+4	long	long	ADV	B	Degree=Pos	28	advmod	_	_
+5	as	as	ADP	E	_	8	mark	_	_
 6	member	member	NOUN	S	Number=Sing	7	nmod	_	_
 7	countries	country	NOUN	S	Number=Plur	8	nsubj	_	_
-8	maintain	maintain	VERB	V	Mood=Ind|Number=Plur|Tense=Pres|VerbForm=Fin	28	advcl	_	_
+8	maintain	maintain	VERB	V	Mood=Ind|Number=Plur|Tense=Pres|VerbForm=Fin	4	advcl	_	_
 9	fiscal	fiscal	ADJ	A	Degree=Pos	10	amod	_	_
 10	sovereignty	sovereignty	NOUN	S	Number=Sing	8	obj	_	SpaceAfter=No
 11	,	,	PUNCT	FF	_	8	punct	_	_

--- a/en_partut-ud-train.conllu
+++ b/en_partut-ud-train.conllu
@@ -26677,8 +26677,8 @@
 16	,	,	PUNCT	FF	_	22	punct	_	_
 17	and	and	CCONJ	CC	_	22	cc	_	_
 18	most	most	ADV	B	_	22	advmod	_	_
-19	of	of	ADP	E	_	18	fixed	_	_
-20	all	all	PRON	PI	PronType=Ind	18	fixed	_	_
+19	of	of	ADP	E	_	20	case	_	_
+20	all	all	PRON	PI	PronType=Ind	18	nmod	_	_
 21	to	to	ADP	E	_	22	case	_	_
 22	Ukraine	Ukraine	PROPN	SP	_	13	conj	_	SpaceAfter=No
 23	,	,	PUNCT	FF	_	22	punct	_	_

--- a/en_partut-ud-train.conllu
+++ b/en_partut-ud-train.conllu
@@ -35396,9 +35396,9 @@
 # text = This is all the more problematic in the case of mosquito control, given the urgency of the problem.
 1	This	this	PRON	PD	Number=Sing|PronType=Dem	6	nsubj	_	_
 2	is	be	AUX	V	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
-3	all	all	DET	T	PronType=Tot	6	advmod	_	_
-4	the	the	DET	RD	Definite=Def|PronType=Art	3	fixed	_	_
-5	more	more	ADV	B	Degree=Cmp	3	fixed	_	_
+3	all	all	ADV	B	_	5	advmod	_	_
+4	the	the	DET	RD	Definite=Def|PronType=Art	5	det	_	_
+5	more	more	ADV	B	Degree=Cmp	6	advmod	_	_
 6	problematic	problematic	ADJ	A	Degree=Pos	0	root	_	_
 7	in	in	ADP	E	_	9	case	_	_
 8	the	the	DET	RD	Definite=Def|PronType=Art	9	det	_	_

--- a/en_partut-ud-train.conllu
+++ b/en_partut-ud-train.conllu
@@ -585,10 +585,10 @@
 19	the	the	DET	RD	Definite=Def|PronType=Art	21	det	_	_
 20	Collective	Collective	PROPN	SP	_	21	nmod	_	_
 21	Work	work	NOUN	S	Number=Sing	18	obj	_	_
-22	apart	apart	ADV	B	_	25	advmod	_	_
+22	apart	apart	ADV	B	_	18	advmod	_	_
 23	from	from	ADP	E	_	25	case	_	_
 24	the	the	DET	RD	Definite=Def|PronType=Art	25	det	_	_
-25	Work	work	NOUN	S	Number=Sing	18	obl	_	_
+25	Work	work	NOUN	S	Number=Sing	22	obl	_	_
 26	itself	it	PRON	PE	Number=Sing|Person=3|PronType=Prs	25	nmod	_	_
 27	to	to	PART	PART	_	29	mark	_	_
 28	be	be	AUX	VA	VerbForm=Inf	29	aux:pass	_	_
@@ -24943,12 +24943,12 @@
 # sent_id = en_partut-ud-1096
 # text = Quite apart from the potential bailout costs, some argue that financial hypertrophy harms the real economy by syphoning off talent and resources that could better be deployed elsewhere.
 1	Quite	quite	ADV	B	_	7	advmod	_	_
-2	apart	apart	ADP	E	_	7	case	_	_
-3	from	from	ADP	E	_	2	fixed	_	_
+2	apart	apart	ADV	B	_	10	advmod	_	_
+3	from	from	ADP	E	_	7	case	_	_
 4	the	the	DET	RD	Definite=Def|PronType=Art	7	det	_	_
 5	potential	potential	ADJ	A	Degree=Pos	7	amod	_	_
 6	bailout	bailout	NOUN	S	Number=Sing	7	nmod	_	_
-7	costs	cost	NOUN	S	Number=Plur	10	obl	_	SpaceAfter=No
+7	costs	cost	NOUN	S	Number=Plur	2	obl	_	SpaceAfter=No
 8	,	,	PUNCT	FF	_	7	punct	_	_
 9	some	some	PRON	PI	PronType=Ind	10	nsubj	_	_
 10	argue	argue	VERB	V	Mood=Ind|Number=Plur|Tense=Pres|VerbForm=Fin	0	root	_	_


### PR DESCRIPTION
This cleans up all the rest of the `fixed` not labeled with `ExtPos`

would like to call attention to this one:

```
# sent_id = en_partut-ud-363
# text = My Group has made extensive amendments to both reports up for debate today.
1       My      my      DET     AP      Number=Sing|Poss=Yes|PronType=Prs       2       nmod:poss       _       _
2       Group   group   NOUN    S       Number=Sing     4       nsubj   _       _
3       has     have    AUX     VA      Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin   4       aux     _       _
4       made    make    VERB    V       Tense=Past|VerbForm=Part        0       root    _       _
5       extensive       extensive       ADJ     A       Degree=Pos      6       amod    _       _
6       amendments      amendment       NOUN    S       Number=Plur     4       obj     _       _
7       to      to      ADP     E       _       9       case    _       _
8       both    both    DET     DI      PronType=Ind    9       det     _       _
9       reports report  NOUN    S       Number=Plur     4       obl     _       _
10      up      up      ADP     E       _       12      case    _       _
11      for     for     ADP     E       _       10      fixed   _       _
12      debate  debate  NOUN    S       Number=Sing     4       obl     _       _
13      today   today   ADV     B       _       4       advmod  _       SpaceAfter=No
14      .       .       PUNCT   FS      _       4       punct   _       _
```

I think here `up for` should be treated as `case/case`, such as if it had a single `under debate` or `under consideration` instead of `up for debate`

@nschneid @amir-zeldes 